### PR TITLE
Fix current series might raise Rubicure::NotOnAirError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,5 @@ gem "sinatra-contrib", "~> 2.0"
 gem "slim", "~> 4.0"
 
 gem "activesupport", "< 6.0.0"
+
+gem "timecop", :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     temple (0.8.2)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timecop (0.9.1)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
 
@@ -77,6 +78,7 @@ DEPENDENCIES
   sinatra (~> 2.0)
   sinatra-contrib (~> 2.0)
   slim (~> 4.0)
+  timecop
 
 BUNDLED WITH
    2.1.3

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Types::QueryType do
   end
 
   # Call `result` to execute the query
-  let(:result) do 
+  let(:result) do
     post '/graphql', query, headers
     res = JSON.parse(last_response.body)
     # Print any errors
@@ -109,15 +109,30 @@ QUERYSTRING
 QUERYSTRING
     end
 
-    context "now" do
+    context "now at 2020-01-26" do
+      around do |e|
+        Timecop.freeze('2020-01-26') { e.run }
+      end
       it "returns current series" do
         expect(result["data"]["now"]["seriesName"]).to eq Precure.now.series_name
       end
     end
 
-    context "current" do
+    context "current at 2020-01-26" do
+      around do |e|
+        Timecop.freeze('2020-01-26') { e.run }
+      end
       it "returns current series" do
         expect(result["data"]["current"]["seriesName"]).to eq Precure.now.series_name
+      end
+    end
+
+    context "at 2020-02-01" do
+      around do |e|
+        Timecop.freeze('2020-02-01') { e.run }
+      end
+      it "returns error" do
+        expect { result }.to raise_error(Rubicure::NotOnAirError)
       end
     end
   end
@@ -134,6 +149,9 @@ QUERYSTRING
 QUERYSTRING
     end
 
+    around do |e|
+      Timecop.freeze('2020-01-26') { e.run }
+    end
     it "returns current series" do
       expect(result["data"]["series"]["seriesName"]).to eq Precure.now.series_name
     end
@@ -151,6 +169,9 @@ QUERYSTRING
 QUERYSTRING
     end
 
+    around do |e|
+      Timecop.freeze('2020-01-26') { e.run }
+    end
     it "returns current series" do
       expect(result["data"]["series"]["seriesName"]).to eq Precure.now.series_name
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rack/test'
 require 'rspec'
 require 'json'
+require 'timecop'
 
 ENV['RACK_ENV'] = 'test'
 


### PR DESCRIPTION
Timecop.freeze('2020-02-01')
Precure.now

raises Rubicure::NotOnAirError

「スター☆トゥインクルプリキュア」放送終了 2020-01-26
「ヒーリングっど♥プリキュア」放送開始 2020-02-02