### PR TITLE
Treat deprecation of PostBodyContentTypeParser

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,7 +4,7 @@ require 'slim'
 require 'rack/contrib'
 require_relative 'graphql/schema'
 
-use Rack::PostBodyContentTypeParser
+use Rack::JSONBodyParser
 
 get '/' do
   slim :index


### PR DESCRIPTION
[DEPRECATION] PostBodyContentTypeParser is deprecated. Use JSONBodyParser as a drop-in replacement.