### PR TITLE
Revert "Bump ruby from 3.0.6-alpine3.16 to 3.0.7-alpine3.16 in /ci/ruby3.0"

### DIFF
--- a/ci/ruby3.0/Dockerfile
+++ b/ci/ruby3.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.7-alpine3.16
+FROM ruby:3.0.6-alpine3.16
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
Reverts seaki/rubicure-sinatra-graphql#358