### PR TITLE
Revert "Drop support for Ruby 2.6"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,7 @@
 rspec_task:
   container:
     matrix:
+      dockerfile: ci/ruby2.6/Dockerfile
       dockerfile: ci/ruby2.7/Dockerfile
       dockerfile: ci/ruby3.0/Dockerfile
       dockerfile: ci/ruby3.1/Dockerfile

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
   schedule:
     interval: daily
 - package-ecosystem: docker
+  directory: "/ci/ruby2.6"
+  schedule:
+    interval: daily
+  ignore:
+  - dependency-name: ruby
+    versions:
+    - ">= 2.7"
+- package-ecosystem: docker
   directory: "/ci/ruby2.7"
   schedule:
     interval: daily

--- a/ci/ruby2.6/Dockerfile
+++ b/ci/ruby2.6/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.6.10-alpine3.15
+
+ENV LANG C.UTF-8
+
+RUN apk update && \
+apk upgrade && \
+apk add --update --no-cache build-base tzdata && \
+gem install bundler -v 2.3.6


### PR DESCRIPTION
Reverts seaki/rubicure-sinatra-graphql#408